### PR TITLE
docs: slight clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+Backpack is a simple package manager that works like [`cargo`](https://doc.rust-lang.org/cargo/guide/dependencies.html) or [`uv`](https://docs.astral.sh/uv/concepts/projects/dependencies/).
+
+---
+
 Declare requirements in `goboscript.toml`
 
 ```toml
@@ -7,7 +11,7 @@ reponame = "username/reponame==1.*.*"
 
 Run `backpack` to lock & install them into the `backpack/` directory.
 
-Commit `backpack-lock.json` to version control.
+Commit `backpack-lock.json` to version control. This file stores the versions of the packages.
 
 Include library code from the `backpack/` directory.
 


### PR DESCRIPTION
when i first found out about this version of backpack i was very confused. i didnt know what a lockfile and stuff was. i think a small reference to cargo and uv could go a long way. also there is a slight clarification about lock files.  i tried to keep the readme minimal as it looked like that was the intention

of course since cargo and uv do a lot more than package management, i linked specific pages about commands like `cargo add` so the parallel is clearer